### PR TITLE
Fix version redefinition in mouse tracker 

### DIFF
--- a/src/citra_libretro/input/mouse_tracker.cpp
+++ b/src/citra_libretro/input/mouse_tracker.cpp
@@ -20,8 +20,6 @@ MouseTracker::MouseTracker() {
     // Could potentially also use Citra's built-in shaders, if they can be
     //  wrangled to cooperate.
     const GLchar* vertex = R"(
-        #version 330 core
-
         in vec2 position;
 
         void main()
@@ -31,8 +29,6 @@ MouseTracker::MouseTracker() {
     )";
 
     const GLchar* fragment = R"(
-        #version 330 core
-
         out vec4 color;
 
         void main()

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -102,9 +102,7 @@ GLuint LoadProgram(bool separable_program, const std::vector<GLuint>& shaders) {
         }
     }
 
-#ifndef __LIBRETRO__
     ASSERT_MSG(result == GL_TRUE, "Shader not linked");
-#endif
 
     for (GLuint shader : shaders) {
         if (shader != 0) {

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -102,7 +102,9 @@ GLuint LoadProgram(bool separable_program, const std::vector<GLuint>& shaders) {
         }
     }
 
+#ifndef __LIBRETRO__
     ASSERT_MSG(result == GL_TRUE, "Shader not linked");
+#endif
 
     for (GLuint shader : shaders) {
         if (shader != 0) {


### PR DESCRIPTION
This should be what was causing the assert to fail, [this commit](https://github.com/RobLoach/citra/commit/d63acfc1e95637e5ab56b4c5df2aa5fbbda024dd#diff-d1566b46689a5ab5c3e5f6f5b5637462) may have broken it.